### PR TITLE
fixed calling next() 2x after throwing

### DIFF
--- a/hooks.js
+++ b/hooks.js
@@ -155,7 +155,7 @@ module.exports = {
 function once (fn, scope) {
   return function fnWrapper () {
     if (fnWrapper.hookCalled) return;
-    fn.apply(scope, arguments);
     fnWrapper.hookCalled = true;
+    fn.apply(scope, arguments);
   };
 }

--- a/test.js
+++ b/test.js
@@ -525,7 +525,7 @@ module.exports = {
     }, 1000);
   },
 
-  'calling the same next multiple times should have the effect of only calling it once': function () {
+  'calling the same next multiple times should have the effect of only calling it once': function (beforeExit) {
     var A = function () {
       this.acked = false;
     };
@@ -535,17 +535,21 @@ module.exports = {
       this.acked = true;
     });
     A.pre('ack', function (next) {
-      next();
-      next();
+      // force a throw to re-exec next()
+      try {
+        next(new Error('bam'));
+      } catch (err) {
+        next();
+      }
     });
     A.pre('ack', function (next) {
-      // Notice that next() is not invoked here
+      next();
     });
     var a = new A();
     a.ack();
-    setTimeout( function () {
+    beforeExit( function () {
       a.acked.should.be.false;
-    }, 1000);
+    });
   },
 
   'asynchronous middleware should be able to pass an error via `done`, stopping the middleware chain': function () {


### PR DESCRIPTION
previously could call next() 2x if the first time was wrapped in a try/catch.
