### PR TITLE
Feature: Added removePost function that mimics removePre

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+## __This is a re-write of the original with different behaviour. Use with caution!__
+
 hooks
 ============
 

--- a/hooks.js
+++ b/hooks.js
@@ -144,6 +144,20 @@ module.exports = {
     (posts[name] = posts[name] || []).push(fn);
     return this;
   },
+  removePost: function (name, fnToRemove) {
+    var proto = this.prototype || this
+      , posts = proto._posts || (proto._posts || {});
+    if (!posts[name]) return this;
+    if (arguments.length === 1) {
+      // Remove all post callbacks for hook `name`
+      posts[name].length = 0;
+    } else {
+      posts[name] = posts[name].filter( function (currFn) {
+        return currFn !== fnToRemove;
+      });
+    }
+    return this;
+  },
   removePre: function (name, fnToRemove) {
     var proto = this.prototype || this
       , pres = proto._pres || (proto._pres || {});

--- a/package.json
+++ b/package.json
@@ -1,7 +1,10 @@
 {
   "name": "hooks",
-  "description": "Adds pre and post hook functionality to your JavaScript methods.",
-  "version": "0.3.2",
+  "description": "
+    Adds pre and post hook functionality to your JavaScript methods.
+    This is a re-write of the original with different behaviour!
+  ",
+  "version": "0.4.0",
   "keywords": [
     "node",
     "hooks",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
   "scripts": {
     "test": "make test"
   },
-  "dependencies": {},
+  "dependencies": {
+    "underscore": ">=1.1.4"
+  },
   "devDependencies": {
     "expresso": ">=0.7.6",
     "should": ">=0.2.1",

--- a/test.js
+++ b/test.js
@@ -627,6 +627,51 @@ module.exports = {
     should.strictEqual(undefined, a.preValueTwo);
   },
 
+  'should be able to remove a particular post': function () {
+    var A = function () {}
+      , postTwo;
+    _.extend(A, hooks);
+    A.hook('save', function () {
+      this.value = 1;
+    });
+    A.post('save', function (next) {
+      this.postValueOne = 2;
+      next();
+    });
+    A.post('save', postTwo = function (next) {
+      this.postValueTwo = 4;
+      next();
+    });
+    A.removePost('save', postTwo);
+    var a = new A();
+    a.save();
+    a.value.should.equal(1);
+    a.postValueOne.should.equal(2);
+    should.strictEqual(undefined, a.postValueTwo);
+  },
+
+  'should be able to remove all posts associated with a hook': function () {
+    var A = function () {};
+    _.extend(A, hooks);
+    A.hook('save', function () {
+      this.value = 1;
+    });
+    A.post('save', function (next) {
+      this.postValueOne = 2;
+      next();
+    });
+    A.post('save', function (next) {
+      this.postValueTwo = 4;
+      next();
+    });
+    A.removePost('save');
+    var a = new A();
+    a.save();
+    a.value.should.equal(1);
+    should.strictEqual(undefined, a.postValueOne);
+    should.strictEqual(undefined, a.postValueTwo);
+  },
+
   '#pre should lazily make a method hookable': function () {
     var A = function () {};
     _.extend(A, hooks);


### PR DESCRIPTION
I found it strange that there wasn't a mirror function for removing post hooks.
